### PR TITLE
Jacoco Plugin Coverage Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,11 @@
             <version>1.12.1</version>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>jacoco</artifactId>
+            <version>3.0.4</version>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>jenkins-core</artifactId>
             <version>2.73.3</version>

--- a/pom.xml
+++ b/pom.xml
@@ -236,12 +236,42 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jacoco</artifactId>
-            <version>3.0.4</version>
+            <version>2.2.1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>jenkins-core</artifactId>
             <version>2.73.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>4.4.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+            <version>5.0.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-container-default</artifactId>
+            <version>1.0-alpha-30</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.reporting</groupId>
+            <artifactId>maven-reporting-api</artifactId>
+            <version>3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.doxia</groupId>
+            <artifactId>doxia-sink-api</artifactId>
+            <version>1.1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.doxia</groupId>
+            <artifactId>doxia-logging-api</artifactId>
+            <version>1.1.2</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/org/jenkinsci/plugins/githubautostatus/BuildStatusJobListener.java
+++ b/src/main/java/org/jenkinsci/plugins/githubautostatus/BuildStatusJobListener.java
@@ -31,6 +31,7 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
 import hudson.plugins.cobertura.CoberturaBuildAction;
+import hudson.plugins.jacoco.JacocoBuildAction;
 import hudson.tasks.junit.TestResultAction;
 import java.util.HashMap;
 import java.util.Map;
@@ -110,10 +111,14 @@ public class BuildStatusJobListener extends RunListener<Run<?, ?>> {
     private CodeCoverage getCoverageData(Run<?, ?> build) {
 
         CoberturaBuildAction coberturaAction = build.getAction(CoberturaBuildAction.class);
+        JacocoBuildAction jacocoBuildAction = build.getAction(JacocoBuildAction.class);
 
         if (coberturaAction != null) {
             return CodeCoverage.fromCobertura(coberturaAction);
+        }else if(jacocoBuildAction != null){
+            return CodeCoverage.fromJacoco(jacocoBuildAction);
         }
+
         return null;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/githubautostatus/BuildStatusJobListener.java
+++ b/src/main/java/org/jenkinsci/plugins/githubautostatus/BuildStatusJobListener.java
@@ -86,7 +86,7 @@ public class BuildStatusJobListener extends RunListener<Run<?, ?>> {
      */
     private Map<String, Object> getParameters(Run<?, ?> build) {
         HashMap<String, Object> result = new HashMap<String, Object>();
-        
+
         Map<JobPropertyDescriptor, ? extends JobProperty<?>> jobProperties = build.getParent().getProperties();
         if (jobProperties != null) {
             for (JobProperty property : jobProperties.values()) {
@@ -105,21 +105,24 @@ public class BuildStatusJobListener extends RunListener<Run<?, ?>> {
     /**
      * Gets code coverage from the build, if present.
      *
+     * If both cobertura and jacoco results are available, jacoco will take precedence
+     *
      * @param build the build.
      * @return code coverage information.
      */
     private CodeCoverage getCoverageData(Run<?, ?> build) {
 
+        CodeCoverage results = null;
         CoberturaBuildAction coberturaAction = build.getAction(CoberturaBuildAction.class);
         JacocoBuildAction jacocoBuildAction = build.getAction(JacocoBuildAction.class);
 
         if (coberturaAction != null) {
-            return CodeCoverage.fromCobertura(coberturaAction);
-        }else if(jacocoBuildAction != null){
-            return CodeCoverage.fromJacoco(jacocoBuildAction);
+            results = CodeCoverage.fromCobertura(coberturaAction);
+        } else if(jacocoBuildAction != null){
+            results = CodeCoverage.fromJacoco(jacocoBuildAction);
         }
 
-        return null;
+        return results;
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/githubautostatus/model/CodeCoverage.java
+++ b/src/main/java/org/jenkinsci/plugins/githubautostatus/model/CodeCoverage.java
@@ -26,6 +26,10 @@ package org.jenkinsci.plugins.githubautostatus.model;
 import hudson.plugins.cobertura.CoberturaBuildAction;
 import hudson.plugins.cobertura.Ratio;
 import hudson.plugins.cobertura.targets.CoverageMetric;
+import hudson.plugins.jacoco.JacocoBuildAction;
+import hudson.plugins.jacoco.model.Coverage;
+import hudson.plugins.jacoco.model.CoverageElement;
+
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -56,6 +60,44 @@ public class CodeCoverage {
             codeCoverage.setLines(results.get(CoverageMetric.LINE));
             codeCoverage.setMethods(results.get(CoverageMetric.METHOD));
             codeCoverage.setPackages(results.get(CoverageMetric.PACKAGES));
+        }
+
+        return codeCoverage;
+    }
+
+    /**
+     * Loads code coverage from Jacoco.
+     *
+     * NOTE: Currently doesn't look like Jacoco is returning package and file specific numbers
+     *
+     * @param jacocoAction Jacoco plugin action
+     * @return CodeCoverage instance with values populated from the action
+     */
+    public static CodeCoverage fromJacoco(@Nullable JacocoBuildAction jacocoAction) {
+        if (jacocoAction == null) {
+            return null;
+        }
+        CodeCoverage codeCoverage = new CodeCoverage();
+        Map<Coverage, Boolean> results = jacocoAction.getCoverageRatios();
+
+
+        for(Coverage c : results.keySet()){
+            switch(c.getType()){
+                case BRANCH:
+                    codeCoverage.setConditionals(c.getPercentageFloat());
+                    break;
+                case LINE:
+                    codeCoverage.setLines(c.getPercentageFloat());
+                    break;
+                case METHOD:
+                    codeCoverage.setMethods(c.getPercentageFloat());
+                    break;
+                case CLASS:
+                    codeCoverage.setClasses(c.getPercentageFloat());
+                    break;
+
+            }
+
         }
 
         return codeCoverage;

--- a/src/main/java/org/jenkinsci/plugins/githubautostatus/model/CodeCoverage.java
+++ b/src/main/java/org/jenkinsci/plugins/githubautostatus/model/CodeCoverage.java
@@ -28,8 +28,6 @@ import hudson.plugins.cobertura.Ratio;
 import hudson.plugins.cobertura.targets.CoverageMetric;
 import hudson.plugins.jacoco.JacocoBuildAction;
 import hudson.plugins.jacoco.model.Coverage;
-import hudson.plugins.jacoco.model.CoverageElement;
-
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -74,14 +72,16 @@ public class CodeCoverage {
      * @return CodeCoverage instance with values populated from the action
      */
     public static CodeCoverage fromJacoco(@Nullable JacocoBuildAction jacocoAction) {
+
         if (jacocoAction == null) {
             return null;
         }
+
         CodeCoverage codeCoverage = new CodeCoverage();
-        Map<Coverage, Boolean> results = jacocoAction.getCoverageRatios();
+        codeCoverage.setFiles(0.0f);
+        codeCoverage.setPackages(0.0f);
 
-
-        for(Coverage c : results.keySet()){
+        for(Coverage c : jacocoAction.getCoverageRatios().keySet()){
             switch(c.getType()){
                 case BRANCH:
                     codeCoverage.setConditionals(c.getPercentageFloat());
@@ -97,7 +97,6 @@ public class CodeCoverage {
                     break;
 
             }
-
         }
 
         return codeCoverage;

--- a/src/main/java/org/jenkinsci/plugins/githubautostatus/notifiers/BuildState.java
+++ b/src/main/java/org/jenkinsci/plugins/githubautostatus/notifiers/BuildState.java
@@ -41,7 +41,7 @@ public enum BuildState {
 
     /**
      * Converts value to Jenkins; result
-     * @return
+     * @return BuildState enum type
      */
     public Result toResult() {
         switch(this) {

--- a/src/test/java/org/jenkinsci/plugins/githubautostatus/model/CodeCoverageTest.java
+++ b/src/test/java/org/jenkinsci/plugins/githubautostatus/model/CodeCoverageTest.java
@@ -1,0 +1,76 @@
+package org.jenkinsci.plugins.githubautostatus.model;
+
+import hudson.plugins.jacoco.JacocoBuildAction;
+import hudson.plugins.jacoco.model.Coverage;
+import hudson.plugins.jacoco.model.CoverageElement;
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(JacocoBuildAction.class)
+public class CodeCoverageTest {
+  @BeforeClass
+  public static void setUpClass() {
+  }
+
+  @AfterClass
+  public static void tearDownClass() {
+  }
+
+  @Before
+  public void setUp() {
+  }
+
+  @After
+  public void tearDown() {
+  }
+
+  @Test
+  public void testFromJacoco_null(){
+    assertNull(CodeCoverage.fromJacoco(null));
+  }
+
+  @Test
+  public void testFromJacoco(){
+    // 100% branch
+    Coverage branch = new Coverage(0, 100);
+    branch.setType(CoverageElement.Type.BRANCH);
+    // 67% line
+    Coverage line  = new Coverage(50, 100);
+    line.setType(CoverageElement.Type.LINE);
+    // 50% method
+    Coverage method = new Coverage(1, 1);
+    method.setType(CoverageElement.Type.METHOD);
+    // 75% class
+    Coverage clazz = new Coverage(5, 15);
+    clazz.setType(CoverageElement.Type.CLASS);
+
+    Map<Coverage, Boolean> jacocoRatios = new HashMap<>();
+    jacocoRatios.put(branch, true);
+    jacocoRatios.put(line, true);
+    jacocoRatios.put(method, true);
+    jacocoRatios.put(clazz, true);
+
+    JacocoBuildAction action = PowerMockito.mock(JacocoBuildAction.class);
+    when(action.getCoverageRatios()).thenReturn(jacocoRatios);
+
+    CodeCoverage coverage = CodeCoverage.fromJacoco(action);
+    assertEquals(0.0, coverage.getFiles(), 0.001);
+    assertEquals(0.0, coverage.getPackages(), 0.001);
+    assertEquals(100.0, coverage.getConditionals(), 0.001);
+    assertEquals(66.667, coverage.getLines(), 0.001);
+    assertEquals(50.000, coverage.getMethods(), 0.001);
+    assertEquals(75.000, coverage.getClasses(), 0.001);
+
+  }
+}


### PR DESCRIPTION
+ Adds ability to calculate coverage from Jacoco plugin (2.2.1), if supplied.
+ Added test case for CodeCoverage.fromJacoco()

Note 1: Adding the Jacoco plugin triggered several dependency enforcement issues.  I added the upper bounded dependencies, but I'm not sure if you want to track them differently.

Note 2: Jacoco 3.x started using dependencies compiled for Java 9, so I stuck with the latest version on the 2.x branch.

 