### PR TITLE
Refactor scmRevisionAction.getRevision()

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/githubautostatus/GithubNotificationConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/githubautostatus/GithubNotificationConfig.java
@@ -40,6 +40,7 @@ import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import jenkins.plugins.git.AbstractGitSCMSource;
+import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMRevisionAction;
 import jenkins.scm.api.SCMSource;
 import org.jenkinsci.plugins.github_branch_source.GitHubSCMSource;
@@ -156,10 +157,11 @@ public class GithubNotificationConfig {
             log(Level.INFO, "Could not find commit sha - status will not be provided for this build");
             return false;
         }
-        if (scmRevisionAction.getRevision() instanceof AbstractGitSCMSource.SCMRevisionImpl) {
-            this.shaString = ((AbstractGitSCMSource.SCMRevisionImpl) scmRevisionAction.getRevision()).getHash();
-        } else if (scmRevisionAction.getRevision() instanceof PullRequestSCMRevision) {
-            this.shaString = ((PullRequestSCMRevision) scmRevisionAction.getRevision()).getPullHash();
+        SCMRevision revision = scmRevisionAction.getRevision();
+        if (revision instanceof AbstractGitSCMSource.SCMRevisionImpl) {
+            this.shaString = ((AbstractGitSCMSource.SCMRevisionImpl) revision).getHash();
+        } else if (revision instanceof PullRequestSCMRevision) {
+            this.shaString = ((PullRequestSCMRevision) revision).getPullHash();
         }
         return true;
     }
@@ -174,10 +176,11 @@ public class GithubNotificationConfig {
         if (null == scmRevisionAction) {
             return false;
         }
-        if (scmRevisionAction.getRevision() instanceof AbstractGitSCMSource.SCMRevisionImpl) {
-            branchName = ((AbstractGitSCMSource.SCMRevisionImpl) scmRevisionAction.getRevision()).getHead().getName();
-        } else if (scmRevisionAction.getRevision() instanceof PullRequestSCMRevision) {
-            PullRequestSCMHead pullRequestSCMHead = (PullRequestSCMHead) ((PullRequestSCMRevision) scmRevisionAction.getRevision()).getHead();
+        SCMRevision revision = scmRevisionAction.getRevision();
+        if (revision instanceof AbstractGitSCMSource.SCMRevisionImpl) {
+            branchName = ((AbstractGitSCMSource.SCMRevisionImpl) revision).getHead().getName();
+        } else if (revision instanceof PullRequestSCMRevision) {
+            PullRequestSCMHead pullRequestSCMHead = (PullRequestSCMHead) ((PullRequestSCMRevision) revision).getHead();
 
             branchName = pullRequestSCMHead.getSourceBranch();
         }


### PR DESCRIPTION
There's no reason to call `getRevision()` 3 times in a row.