### PR TITLE
Find nested stages for declarative pipelines.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>org.jenkinsci.plugins</groupId>
             <artifactId>pipeline-model-api</artifactId>
-            <version>1.2.1</version>
+            <version>1.3</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -116,12 +116,17 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>display-url-api</artifactId>
-            <version>0.2</version>
+            <version>1.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
             <version>3.5.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>git-client</artifactId>
+            <version>2.7.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -142,22 +147,22 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
-            <version>2.2.2</version>
+            <version>2.2.6</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.22</version>
+            <version>2.25</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.36.1</version>
+            <version>2.46</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.11</version>
+            <version>2.15</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -167,12 +172,22 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-scm-step</artifactId>
-            <version>2.4</version>
+            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>org.jenkinsci.plugins</groupId>
             <artifactId>pipeline-model-definition</artifactId>
-            <version>1.2.1</version>
+            <version>1.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>mailer</artifactId>
+            <version>1.20</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>script-security</artifactId>
+            <version>1.42</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>


### PR DESCRIPTION
Hello,

Thanks for creating this really useful plugin!  It will allow me to remove all of the explicit logging from my pipelines which will make them much tidier.

I have some complex declarative pipelines that have some nested stages and I found that only the top-level stages were being recorded.  This seems to be easily fixed by recursing the JSON data for the stages.

I have tested the change with the following pipeline and everything worked as expected:

```
pipeline {
    agent any
    stages {
        stage("Outer Stage") {
            stages {
                stage("Inner Stage 1") {
                    steps {
                        echo "Inner stage 1"
                    }
                }
                stage("Inner Stage 2") {
                    steps {
                        echo "Inner stage 2"
                    }
                }
                stage("Inner Stage 3") {
                    stages {
                        stage("Inner Inner Stage 1") {
                            steps {
                                echo "Inner inner stage 1"
                            }
                        }
                    }
                }
            }
        }
        stage("Outer Stage 2") {
            parallel {
                stage("Parallel Stage 1") {
                    steps {
                        echo "Parallel stage 1"
                    }
                }
                stage("Parallel Stage 2") {
                    steps {
                        echo "Parallel stage 2"
                    }
                }
            }
        }
    }
}
```

Please can you consider this pull request or something equivalent so that all of the stage data is logged?

Many thanks