### PR TITLE
Find stages within a parallel block

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/githubautostatus/GithubBuildStatusGraphListener.java
+++ b/src/main/java/org/jenkinsci/plugins/githubautostatus/GithubBuildStatusGraphListener.java
@@ -274,7 +274,7 @@ public class GithubBuildStatusGraphListener implements GraphListener {
 
     }
 
-    private static List<String> getDeclarativeStages(Run<?, ?> run) {
+    protected static List<String> getDeclarativeStages(Run<?, ?> run) {
         ExecutionModelAction executionModelAction = run.getAction(ExecutionModelAction.class);
         if (null == executionModelAction) {
             return null;
@@ -313,14 +313,14 @@ public class GithubBuildStatusGraphListener implements GraphListener {
     private static List<String> getAllStageNames(ModelASTStage stage) {
         List<String> stageNames = new ArrayList<>();
         stageNames.add(stage.getName());
-        ModelASTStages stages = stage.getStages();
-        if (stages == null) {
-            stages = stage.getParallel();
+        List<ModelASTStage> stageList = null;
+        if (stage.getStages() != null) {
+            stageList = stage.getStages().getStages();
+        } else {
+            stageList = stage.getParallelContent();
         }
-        if (stages != null) {
-            for (ModelASTStage innerStage : stages.getStages()) {
-                stageNames.addAll(getAllStageNames(innerStage));
-            }
+        for (ModelASTStage innerStage : stageList) {
+            stageNames.addAll(getAllStageNames(innerStage));
         }
         return stageNames;
     }

--- a/src/test/java/org/jenkinsci/plugins/githubautostatus/GithubBuildStatusGraphListenerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/githubautostatus/GithubBuildStatusGraphListenerTest.java
@@ -130,20 +130,23 @@ public class GithubBuildStatusGraphListenerTest {
         ExecutionModelAction executionModel = mock(ExecutionModelAction.class);
         when(build.getAction(ExecutionModelAction.class)).thenReturn(executionModel);
 
+        // Construct a complex pipeline model
         ModelASTStages stages = createStages("Outer Stage 1", "Outer Stage 2");
         ModelASTStages innerStages = createStages("Inner Stage 1", "Inner Stage 2", "Inner Stage 3");
         ModelASTStages innerInnerStages = createStages("Inner Inner Stage 1");
         ModelASTStages parallelStages = createStages("Parallel Stage 1", "Parallel Stage 2");
-        List<String> fullStageList = Arrays.asList(new String[] {"Outer Stage 1", "Inner Stage 1", "Inner Stage 2", "Inner Stage 3", "Inner Inner Stage 1", "Outer Stage 2", "Parallel Stage 1", "Parallel Stage 2"});
         stages.getStages().get(0).setStages(innerStages);
         innerStages.getStages().get(2).setStages(innerInnerStages);
         stages.getStages().get(1).setParallelContent(parallelStages.getStages());
+        // Create a linear list of the pipeline stages for comparison
+        List<String> fullStageList = Arrays.asList(new String[] {"Outer Stage 1", "Inner Stage 1", "Inner Stage 2", "Inner Stage 3", "Inner Inner Stage 1", "Outer Stage 2", "Parallel Stage 1", "Parallel Stage 2"});
 
         when(executionModel.getStages()).thenReturn(stages);
 
         GithubBuildStatusGraphListener instance = new GithubBuildStatusGraphListener();
         instance.onNewHead(stageNode);
         verify(build).addAction(any(BuildStatusAction.class));
+        // Check that the pipeline stages found match the list of expected stages
         assertTrue(GithubBuildStatusGraphListener.getDeclarativeStages(build).equals(fullStageList));
     }
 


### PR DESCRIPTION
Hi @jeffpearce 

Here is another pull request that fixes the problem whereby stages in a parallel block were not being found.  I have also added a unit test to check that all stages in a complex pipeline are found.
I would be very grateful if you could merge this.

Many thanks

Alex