### PR TITLE
Don't send non-stage errors to github

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/githubautostatus/BuildStageModel.java
+++ b/src/main/java/org/jenkinsci/plugins/githubautostatus/BuildStageModel.java
@@ -38,6 +38,7 @@ public class BuildStageModel {
     private HashMap<String, Object> environment;
     private BuildState buildState;
     private transient Run<?, ?> run;
+    private boolean isStage = true;
     
     public BuildStageModel(String stageName) {
         this(stageName, new HashMap<String, Object>());
@@ -90,6 +91,14 @@ public class BuildStageModel {
 
     public void setRun(Run<?, ?> run) {
         this.run = run;
+    }
+    
+    public boolean isStage() {
+        return this.isStage;
+    }
+    
+    public void setIsStage(boolean isStage) {
+        this.isStage = isStage;
     }
     
 }

--- a/src/main/java/org/jenkinsci/plugins/githubautostatus/BuildStatusAction.java
+++ b/src/main/java/org/jenkinsci/plugins/githubautostatus/BuildStatusAction.java
@@ -230,7 +230,7 @@ public class BuildStatusAction extends InvisibleAction {
     /**
      * Sends notifications for an error that happens outside of a stage
      *
-     * @param nodeName name of node
+     * @param nodeName name of node that failed
      */
     public void sendNonStageError(String nodeName) {
         BuildStageModel stageItem = new BuildStageModel(nodeName,
@@ -238,7 +238,8 @@ public class BuildStatusAction extends InvisibleAction {
                 BuildState.CompletedError);
         stageItem.setRun(run);
         stageItem.addToEnvironment(jobParameters);
+        stageItem.setIsStage(false);
         buildStatuses.put(nodeName, stageItem);
-        buildNotifierManager.sendNonStageError(nodeName);
+        buildNotifierManager.sendNonStageError(stageItem);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/githubautostatus/notifiers/BuildNotifierManager.java
+++ b/src/main/java/org/jenkinsci/plugins/githubautostatus/notifiers/BuildNotifierManager.java
@@ -120,11 +120,9 @@ public class BuildNotifierManager {
      * status was sent. Useful for reporting errors for non-declarative
      * pipelines when they happen outside of a stage.
      *
-     * @param nodeName the name of the node that failed
+     * @param stageItem stage item
      */
-    public void sendNonStageError(String nodeName) {
-        BuildStageModel stageItem = new BuildStageModel(nodeName);
-        stageItem.setBuildState(BuildState.CompletedError);
+    public void sendNonStageError(BuildStageModel stageItem) {
         notifiers.forEach((notifier) -> {
             notifier.notifyBuildStageStatus(jobName, stageItem);
         });

--- a/src/main/java/org/jenkinsci/plugins/githubautostatus/notifiers/GithubBuildNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/githubautostatus/notifiers/GithubBuildNotifier.java
@@ -90,6 +90,9 @@ public class GithubBuildNotifier extends BuildNotifier {
      */
     @Override
     public void notifyBuildStageStatus(String jobName, BuildStageModel stageItem) {
+        if (!stageItem.isStage()) {
+            return;
+        }
         try {
             BuildState buildState = stageItem.getBuildState();
             repository.createCommitStatus(shaString, STATE_MAP.get(buildState), targetUrl, DESCRIPTION_MAP.get(buildState), stageItem.getStageName());

--- a/src/test/java/org/jenkinsci/plugins/githubautostatus/notifiers/BuildNotifierManagerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/githubautostatus/notifiers/BuildNotifierManagerTest.java
@@ -24,6 +24,7 @@
 package org.jenkinsci.plugins.githubautostatus.notifiers;
 
 import java.util.Collections;
+import java.util.HashMap;
 import org.jenkinsci.plugins.githubautostatus.BuildStageModel;
 import org.jenkinsci.plugins.githubautostatus.GithubNotificationConfig;
 import org.jenkinsci.plugins.githubautostatus.InfluxDbNotifierConfig;
@@ -139,7 +140,14 @@ public class BuildNotifierManagerTest {
     public void testSendNonStageError() {
         GithubBuildNotifier notifier = mock(GithubBuildNotifier.class);
         instance.notifiers.add(notifier);
-        instance.sendNonStageError(stageName);
+
+        BuildStageModel stageItem = new BuildStageModel(stageName,
+                new HashMap<>(),
+                BuildState.CompletedError);
+        stageItem.setIsStage(false);
+
+
+        instance.sendNonStageError(stageItem);
 
         verify(notifier).notifyBuildStageStatus(eq(mockJobName), any(BuildStageModel.class));
     }

--- a/src/test/java/org/jenkinsci/plugins/githubautostatus/notifiers/GithubBuildNotifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/githubautostatus/notifiers/GithubBuildNotifierTest.java
@@ -148,4 +148,22 @@ public class GithubBuildNotifierTest {
         notifier.notifyFinalBuildStatus(BuildState.CompletedSuccess, Collections.EMPTY_MAP);
         verify(repository, never()).createCommitStatus(any(), any(), any(), any());
     }
+    
+    /**
+     * Verifies notifier doesn't report errors that happen outside a stage.
+     *
+     * @throws java.io.IOException
+     */
+    @Test
+    public void testNonStageError() throws IOException {
+        GithubBuildNotifier notifier = new GithubBuildNotifier(repository, sha, targetUrl);
+
+        BuildStageModel stageItem = new BuildStageModel(stageName);
+        stageItem.setIsStage(false);
+        stageItem.setBuildState(BuildState.CompletedError);
+        
+        notifier.notifyBuildStageStatus(jobName, stageItem);
+
+        verify(repository, never()).createCommitStatus(any(), any(), any(), any());
+    }
 }


### PR DESCRIPTION
The errors that happen outside a stage should not be sent to github. Fixes #31 