### PR TITLE
Simplify plugin configuration in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,30 +50,6 @@
             <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.2</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                    <!-- attached to Maven test phase -->
-                    <execution>
-                        <id>report</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
     <dependencies>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
         <jenkins.version>2.138.4</jenkins.version>
         <java.level>8</java.level>
         <powermock.version>1.7.4</powermock.version>
+        <hpi.compatibleSinceVersion>4.0</hpi.compatibleSinceVersion>
     </properties>
     <name>Job and Stage monitoring Plugin</name>
     <description>Automatically provides job and stage timing and pass/fail stats to GitHub and/or InfluxDB/Grafana.</description>
@@ -51,14 +52,6 @@
     </pluginRepositories>
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.jenkins-ci.tools</groupId>
-                <artifactId>maven-hpi-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <compatibleSinceVersion>4.0</compatibleSinceVersion>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>


### PR DESCRIPTION
These verbose plugin configuration blocks are not required.