### PR TITLE
Upgrade Mockito & PowerMock

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <jenkins.version>2.138.4</jenkins.version>
         <java.level>8</java.level>
-        <powermock.version>1.7.4</powermock.version>
+        <powermock.version>2.0.2</powermock.version>
         <hpi.compatibleSinceVersion>4.0</hpi.compatibleSinceVersion>
     </properties>
     <name>Job and Stage monitoring Plugin</name>
@@ -204,9 +204,15 @@
             <version>1.42</version>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>support-core</artifactId>
+            <version>2.32</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>2.0.2-beta</version>
+            <artifactId>mockito-core</artifactId>
+            <version>3.1.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -217,19 +223,13 @@
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
-            <artifactId>powermock-core</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
             <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
+            <artifactId>powermock-api-mockito2</artifactId>
             <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>

--- a/src/test/java/org/jenkinsci/plugins/githubautostatus/config/GithubNotificationConfigTest.java
+++ b/src/test/java/org/jenkinsci/plugins/githubautostatus/config/GithubNotificationConfigTest.java
@@ -26,7 +26,6 @@ package org.jenkinsci.plugins.githubautostatus.config;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
-import hudson.model.AbstractBuild;
 import hudson.model.Run;
 import jenkins.plugins.git.AbstractGitSCMSource.SCMRevisionImpl;
 import jenkins.scm.api.SCMRevision;
@@ -95,7 +94,7 @@ public class GithubNotificationConfigTest {
 
     @Test
     public void testConfigBranchSource() throws Exception {
-        AbstractBuild build = Mockito.mock(AbstractBuild.class);
+        Run build = Mockito.mock(Run.class);
         SCMRevisionAction mockSCMRevisionAction = mock(SCMRevisionAction.class);
         when(build.getAction(SCMRevisionAction.class)).thenReturn(mockSCMRevisionAction);
 
@@ -127,7 +126,7 @@ public class GithubNotificationConfigTest {
         PowerMockito.when(builder.build()).thenReturn(github);
         PowerMockito.when(builder.withEndpoint(any())).thenReturn(builder);
 
-        GithubNotificationConfig instance = GithubNotificationConfig.fromRun((Run<WorkflowJob, ?>) build,  builder);
+        GithubNotificationConfig instance = GithubNotificationConfig.fromRun(build, builder);
         assertEquals("what-the-hash", instance.getShaString());
         assertEquals("test-branch", instance.getBranchName());
     }
@@ -135,12 +134,12 @@ public class GithubNotificationConfigTest {
     @Test
     public void testDisabledInConfig() {
         when(config.getEnableGithub()).thenReturn(false);
-        assertNull(GithubNotificationConfig.fromRun(mock(AbstractBuild.class), null));
+        assertNull(GithubNotificationConfig.fromRun(mock(Run.class), null));
     }
 
 //    @Test
 //    public void testConfigPullRequest() throws Exception {
-//        AbstractBuild build = Mockito.mock(AbstractBuild.class);
+//        Run build = Mockito.mock(Run.class);
 //        SCMRevisionAction mockSCMRevisionAction = mock(SCMRevisionAction.class);
 //        when(build.getAction(SCMRevisionAction.class)).thenReturn(mockSCMRevisionAction);
 //
@@ -169,6 +168,6 @@ public class GithubNotificationConfigTest {
 //        PowerMockito.when(builder.withEndpoint(any())).thenReturn(builder);
 //
 //
-//        GithubNotificationConfig instance = GithubNotificationConfig.fromRun(build, null, builder);
+//        GithubNotificationConfig instance = GithubNotificationConfig.fromRun(build, builder);
 //    }
 }


### PR DESCRIPTION
Mockito is more strict now, therefore some small changes have to be applied.

1) use `Run` instead of `AbstractBuild` for `WorkflowJob`
Otherwise a `ClassCastException` is thrown.

2) add 'support-core' as test dependency
This is an optional dependency of 'workflow-cps' and therefore not a transitive dependency of this plugin. It's required for mocking `CpsFlowExecution` now, otherwise the `Component` class cannot be found.