### PR TITLE
Upgrade parent pom & use dependency versions from it

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.50</version>
-        <relativePath />
+        <version>3.55</version>
     </parent>
     <artifactId>github-autostatus</artifactId>
     <version>3.6.2-SNAPSHOT</version>
@@ -13,7 +12,6 @@
     <properties>
         <jenkins.version>2.150.3</jenkins.version>
         <java.level>8</java.level>
-        <powermock.version>2.0.2</powermock.version>
         <hpi.compatibleSinceVersion>3.0</hpi.compatibleSinceVersion>
         <configuration-as-code.version>1.34</configuration-as-code.version>
     </properties>
@@ -187,19 +185,22 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.1.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito2</artifactId>
-            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
There is no need to define versions for dependencies from the parent pom.

Declare Hamcrest dependency explicitly as it is also used in tests.