### PR TITLE
Batch influxdb POST requests

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/githubautostatus/notifiers/InfluxDbNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/githubautostatus/notifiers/InfluxDbNotifier.java
@@ -248,7 +248,7 @@ public class InfluxDbNotifier extends BuildNotifier {
                     buildCause);
 
             postData(data);
-
+	    
             for (TestSuite testSuite : testResults.getTestSuites()) {
                 notifyTestSuite(jobName, testSuite, run);
             }
@@ -261,6 +261,7 @@ public class InfluxDbNotifier extends BuildNotifier {
         int buildNumber = run.getNumber();
         Cause cause = run.getCause(Cause.class);
         String buildCause = cause == null ? BuildNotifierConstants.DEFAULT_STRING : cause.getShortDescription();
+	List<String> testSuiteQuery = new ArrayList<>();
 
         String data = config.getSchema().formatTestSuite(jobName,
                 repoOwner,
@@ -275,14 +276,15 @@ public class InfluxDbNotifier extends BuildNotifier {
                 buildNumber,
                 buildCause);
 
-        postData(data);
-
+	testSuiteQuery.add(data);
         for (TestCase testCase : testSuite.getTestCases()) {
-            notifyTestCase(jobName, suiteName, testCase, run);
+            testSuiteQuery.add(notifyTestCase(jobName, suiteName, testCase, run));
         }
+	postData(String.join("\\n", testSuiteQuery))
+	
     }
 
-    private void notifyTestCase(String jobName, String suiteName, TestCase testCase, Run<?, ?> run) {
+    private String notifyTestCase(String jobName, String suiteName, TestCase testCase, Run<?, ?> run) {
         String buildUrl = run.getUrl();
         int buildNumber = run.getNumber();
         Cause cause = run.getCause(Cause.class);
@@ -301,7 +303,7 @@ public class InfluxDbNotifier extends BuildNotifier {
                 buildNumber,
                 buildCause);
 
-        postData(data);
+	return data;
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/githubautostatus/notifiers/InfluxDbNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/githubautostatus/notifiers/InfluxDbNotifier.java
@@ -280,7 +280,7 @@ public class InfluxDbNotifier extends BuildNotifier {
         for (TestCase testCase : testSuite.getTestCases()) {
             testSuiteQuery.add(notifyTestCase(jobName, suiteName, testCase, run));
         }
-	postData(String.join("\\n", testSuiteQuery))
+	postData(String.join("\\n", testSuiteQuery));
 	
     }
 


### PR DESCRIPTION
Rather then sending a request for each individual test case, I made a change that will batch the POST requests per test suite which will result in a single HTTP Post request being made that includes the test suite datapoint as well as all the test cases datapoints.

This follows the recommendation from influxdb to batch requests to the server with between 5-10K datapoints per request. This significantly reduces the number of writes InfluxDB has to perform as well as reduces overhead resulting from large numbers of HTTP requests coming in at one time.